### PR TITLE
Fix lowercase `scrollmirror` on CDNs by adding key `amdName`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrollmirror",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrollmirror",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "ISC",
       "devDependencies": {
         "@astrojs/mdx": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "scrollmirror",
-  "version": "0.0.2",
+  "amdName": "ScrollMirror",
+  "version": "0.0.3",
   "description": "Sync the scroll position of multiple elements on your page",
   "author": {
     "name": "Rasso Hilber",


### PR DESCRIPTION
**Before**

```astro
<script is:inline src="https://www.unpkg.com/scrollmirror"></script>
<script is:inline>
	new scrollmirror(document.querySelectorAll('.scroller')); // only lowercase working 🙈
</script>
```

**After**

```astro
<script is:inline src="https://www.unpkg.com/scrollmirror"></script>
<script is:inline>
	new ScrollMirror(document.querySelectorAll('.scroller')); // Working as expected 🤠
</script>
```