### PR TITLE
Add API for getting and setting the progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm i scrollmirror
 ```
 
 ```js
-import ScrollMirror from 'scrollmirror';
+import ScrollMirror from "scrollmirror";
 ```
 
 Or include the minified production file from a CDN:
@@ -72,11 +72,11 @@ See also this [minimal example on CodePen](https://codepen.io/rassohilber/pen/Jj
 💡 To mirror the scroll position from and to the `window`, you would have to add one of `:root`, `html` or `body` to the selector:
 
 ```js
-new ScrollMirror(document.querySelectorAll(':root, .scroller'));
+new ScrollMirror(document.querySelectorAll(":root, .scroller"));
 /** or */
-new ScrollMirror(document.querySelectorAll('html, .scroller'));
+new ScrollMirror(document.querySelectorAll("html, .scroller"));
 /** or */
-new ScrollMirror(document.querySelectorAll('body, .scroller'));
+new ScrollMirror(document.querySelectorAll("body, .scroller"));
 ```
 
 ## Options
@@ -91,15 +91,10 @@ The type signature of the options object:
 
 ```js
 type Options = {
-  proportional: boolean;
   vertical: boolean;
   horizontal: boolean;
 }
 ```
-
-### `proportional`
-
-Type: `boolean`, default: `true`. Should the scrolling speed be adjusted so that all mirrored elements reach the maximum scroll position at the same time?
 
 ### `vertical`
 
@@ -108,6 +103,35 @@ Type: `boolean`, default: `true`. Should the vertical scroll position be mirrore
 ### `horizontal`
 
 Type: `boolean`, default: `true`. Should the horizontal scroll position be mirrored?
+
+## API
+
+To access ScrollMirror's API, you have to save a reference to the class during instaciation:
+
+```js
+const mirror = new ScrollMirror(document.querySelectorAll(".scroller"));
+```
+
+### `mirror.progress`
+
+Returns the current scroll progress in the form of `{x: number, y: number}`, where both x and y are a
+number between 0-1
+
+### `mirror.progress = value`
+
+Sets the progress and scrolls all mirrored elements. For example:
+
+```js
+mirror.progress = { x: 0.2, y: 0.5 };
+// or only set one direction
+mirror.progress = { y: 0.5 };
+// or for both directions at once:
+mirror.progress = 0.5;
+```
+
+### `mirror.getScrollProgress(element: HTMLElement)`
+
+Return the current progress of an element. The element doesn't _need_ to be one of the mirrored elements
 
 ## Motivation
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -3,7 +3,6 @@ import Layout from "../layouts/Layout.astro";
 import VerticalExample from "../components/examples/Vertical.astro";
 import HorizontalExample from "../components/examples/Horizontal.astro";
 import BothDirectionsExample from "../components/examples/BothDirections.astro";
-import WindowExample from "../components/examples/WindowExample.astro";
 import { ArrowRightIcon } from "astro-feather";
 ---
 
@@ -46,13 +45,25 @@ import { ArrowRightIcon } from "astro-feather";
 
 <script>
   import ScrollMirror from "../../../src/index.js";
+import Horizontal from "../components/examples/Horizontal.astro";
 
   import { $$ } from "../js/helpers";
-  /** Vertical mirroring */
-  new ScrollMirror($$(".scroller.--vertical"));
-  /** Horizontal mirroring */
-  new ScrollMirror($$(".scroller.--horizontal"));
-  /** Mirroring in both directions */
-  new ScrollMirror($$(".scroller.--both"));
+
+  declare global {
+    interface Window {
+      mirrors: {
+        vertical: ScrollMirror,
+        horizontal: ScrollMirror,
+        both: ScrollMirror
+      };
+    }
+  }
+
+  /** Setup mirrors */
+  window.mirrors = {
+    vertical: new ScrollMirror($$(".scroller.--vertical")),
+    horizontal: new ScrollMirror($$(".scroller.--horizontal")),
+    both: new ScrollMirror($$(".scroller.--both"))
+  }
 
 </script>

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "docs:build": "astro build --root docs",
     "docs:serve": "astro build --root docs && astro preview --root docs",
     "test": "pnpm run test:e2e",
-    "test:e2e": "pnpm playwright test --config ./tests/e2e/config.playwright.ts",
-    "test:e2e:dev": "PLAYWRIGHT_ENV=dev pnpm run test:e2e -- --ui",
+    "test:e2e": "pnpm exec playwright test --config ./tests/e2e/config.playwright.ts",
+    "test:e2e:dev": "PLAYWRIGHT_ENV=dev pnpm run test:e2e --ui",
     "test:e2e:install": "pnpm exec playwright install --with-deps"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export default class ScrollMirror {
 
   constructor(
     elements: NodeListOf<Element> | Element[],
-    options: Partial<Options> = {}
+    options: Partial<Options> = {},
   ) {
     this.elements = [...elements]
       .filter(Boolean)
@@ -53,7 +53,7 @@ export default class ScrollMirror {
     if (this.elements.includes(document.documentElement)) {
       this.mirrorScrollPositions(
         this.getScrollProgress(document.documentElement),
-        document.documentElement
+        document.documentElement,
       );
     }
   }
@@ -95,7 +95,7 @@ export default class ScrollMirror {
       ) {
         console.warn(
           `${this.prefix} no "overflow: auto;" or "overflow: scroll;" set on element:`,
-          element
+          element,
         );
       }
     }
@@ -148,14 +148,14 @@ export default class ScrollMirror {
 
     this.mirrorScrollPositions(
       this.getScrollProgress(scrolledElement),
-      scrolledElement
+      scrolledElement,
     );
   };
 
   /** Mirror the scroll positions of all elements to a target @internal */
   mirrorScrollPositions(
     progress: Progress,
-    ignore: HTMLElement | undefined = undefined
+    ignore: HTMLElement | undefined = undefined,
   ) {
     this.elements.forEach((element) => {
       /* Ignore the currently scrolled element  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export type Options = {
   horizontal: boolean;
 };
 
-type Progress = {
+export type Progress = {
   x: number;
   y: number;
 };

--- a/tests/e2e/tests/api.spec.ts
+++ b/tests/e2e/tests/api.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+import {
+  scrollTo,
+  scrollToEnd,
+  expectScrollPosition,
+  sleep,
+  expectProgress,
+  setProgress,
+} from "./support";
+
+test.describe("API", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("gets the current progress after mirroring", async ({ page }) => {
+    await scrollToEnd(page, "first-vertical");
+    await sleep(1000);
+    await expectProgress(page, "vertical", { x: 0, y: 1 });
+  });
+
+  test("sets the progress vertically", async ({ page }) => {
+    await setProgress(page, "vertical", { y: 0.5 });
+    await expectProgress(page, "vertical", { x: 0, y: 0.5 });
+  });
+
+  test("sets the progress horizontally", async ({ page }) => {
+    await setProgress(page, "horizontal", { x: 0.5 });
+    await expectProgress(page, "horizontal", { x: 0.5, y: 0 });
+  });
+
+  test("sets the progress in both directions", async ({ page }) => {
+    // two values (x, y)
+    await setProgress(page, "both", { x: 0.25, y: 0.75 });
+    await expectProgress(page, "both", { x: 0.25, y: 0.75 });
+
+    // And one value for both directions
+    await setProgress(page, "both", 0.5);
+    await expectProgress(page, "both", { x: 0.5, y: 0.5 });
+  });
+});

--- a/tests/e2e/tests/mirroring.spec.ts
+++ b/tests/e2e/tests/mirroring.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { scrollTo, scrollToEnd, expectScrollPosition, sleep } from "./support";
 
-test.describe("Features", () => {
+test.describe("Mirroring", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
   });

--- a/tests/e2e/tests/support.ts
+++ b/tests/e2e/tests/support.ts
@@ -6,6 +6,19 @@ type ScrollPosition = {
   y: number;
 };
 
+import ScrollMirror from "../../../src/index.js";
+import type { Progress } from "../../../src/index.js";
+
+declare global {
+  interface Window {
+    mirrors: {
+      vertical: ScrollMirror,
+      horizontal: ScrollMirror,
+      both: ScrollMirror
+    };
+  }
+}
+
 export function scrollTo(
   page: Page,
   position: Partial<ScrollPosition>,
@@ -70,4 +83,34 @@ export async function expectScrollPosition(
     };
   }, testId);
   expect(scrollY).toEqual(expected);
+}
+
+export async function setProgress(
+  page: Page,
+  instance: string,
+  progress: Partial<Progress> | number
+) {
+  await page.evaluate(
+    ({ instance, progress }): Progress => {
+      return (window.mirrors[instance].progress = progress);
+    },
+    { instance, progress }
+  );
+}
+
+function roundTwoDecimals(value: number) {
+  return Math.round(value * 100) / 100;
+}
+
+export async function expectProgress(
+  page: Page,
+  instance: string,
+  expected: Progress
+) {
+  const progress = await page.evaluate((instance): Progress => {
+    return window.mirrors[instance].progress;
+  }, instance);
+
+  expect(roundTwoDecimals(progress.x)).toEqual(expected.x);
+  expect(roundTwoDecimals(progress.y)).toEqual(expected.y);
 }


### PR DESCRIPTION
**Description**

Add an API for getting and setting the scroll progress:

```js
// getter
const progress = mirror.progress;
// setter
mirror.progress = {x: 0, y: 0.5};
// ...or only change one direction
mirror.progress = {y: 0.5};
// ...or, for both directions at once
mirror.progress = 0.5;
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was formatted before pushing (`npm run format`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required

**Additional information**

<!--
Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc.
-->
