### PR TITLE
feat: make scroll event handler passive

### DIFF
--- a/src/ScrollMirror.ts
+++ b/src/ScrollMirror.ts
@@ -1,9 +1,5 @@
 import type { Progress, Options, Logger } from "./support/defs.js";
-import {
-  getScrollProgress,
-  hasOverflow,
-  nextTick,
-} from "./support/helpers.js";
+import { getScrollProgress, hasOverflow, nextTick } from "./support/helpers.js";
 
 import {
   getScrollEventTarget,
@@ -22,7 +18,7 @@ export default class ScrollMirror {
   readonly defaults: Options = {
     vertical: true,
     horizontal: true,
-    debug: true
+    debug: true,
   };
   /** The parsed options */
   options: Options;

--- a/src/ScrollMirror.ts
+++ b/src/ScrollMirror.ts
@@ -84,7 +84,7 @@ export default class ScrollMirror {
     this.removeScrollHandler(element);
 
     const target = getScrollEventTarget(element);
-    target.addEventListener("scroll", this.handleScroll);
+    target.addEventListener("scroll", this.handleScroll, { passive: true });
   }
 
   /** Remove the scroll handler from an element @internal */


### PR DESCRIPTION
**Description**

Make the scroll handler passive as we never need to call `preventDefault()` on it.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was formatted before pushing (`npm run format`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required
