### PR TITLE
Replace preinstall script with devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "dist"
   ],
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "clean": "rm -rf ./dist",
     "format": "pnpm exec prettier 'src/**/*.{js,ts,mjs}' --write",
     "prepublishOnly": "pnpm run build",
@@ -61,5 +60,11 @@
     "prettier": "^3.3.3",
     "typescript": "^5.6.2",
     "vitest": "^2.1.1"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
**Description**

The current `preinstall` script in this package is causing issues in CI for folks using npm, see https://github.com/sanity-io/sanity/issues/8852

This replaces the `preinstall` script with [`devEngines`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) which should not apply to consumers of this package, devEngines has been supported since `npm@10.9.0`

**Checks**
- [x] The PR is submitted to the `main` branch
- [ ] The code was formatted before pushing (`pnpm run format`) No, because it caused unrelated changes
- [x] All tests are passing (`pnpm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required

**Additional information**
